### PR TITLE
feat: add mode option, remove watch/compatibility and prevent event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ Server:
 cwk run
 ```
 
-If you have admins, generate an app key for JWT authentication first:
-
-```sh
-cwk generate-key
-```
-
 > To run a locally installed npm binary (cwk in this case), either use package.json scripts property, or run it directly using `yarn cwk` or `(npm bin)/cwk`.
 
 ## Configuration
@@ -62,213 +56,57 @@ First of all, you will need a `cwk.config.js` file in your workshop root directo
 
 This will need to include a default export which contains a JavaScript Object with configuration options.
 
-### Participants
-
 Most importantly, you should add the `participants` key which accepts an array of participant names. Also, add a title for you workshop if you like :)!
+
+If you are the host of the workshop, you can add yourself too, this is easy if you want to demonstrate code during your workshop in your own folder.
 
 ```js
 export default {
   participants: ['Joren', 'Felix'],
   title: 'Frontend Workshop', // Title of the workshop displayed on the main page when launching CWK
+  mode: 'module', // default is 'iframe'
 }
 ```
 
-If you are the host of the workshop, you can add yourself too, this is easy if you want to demonstrate code during your workshop in your own folder.
+You can choose between `iframe` and `module` mode. `iframe` is the default, but generally speaking `module` is a way better experience, but the prerequisite is that your participant `index.js` contain a default export.
 
-### Scaffolding data
+For more information about `mode` option for using `module` and enabling the HMR feature, see [detailed explanation module mode](https://github.com/code-workshop-kit/cwk-frontend/tree/master/docs/module-mode.md)
 
-If you want to generate some starting files for your participants in their own dedicated folder, use `templateData`.
+There are also a lot of other advanced configuration, like adding admins or changing file control behavior. [See full config docs](https://github.com/code-workshop-kit/cwk-frontend/tree/master/docs/config.md)
 
-This accepts an object which accepts any data which can be used inside your template files to fill in variables. You can also put methods in here, and you can access other templateData variables through `this` directly.
+## Scaffolding
 
-There is also the special `this.participantName` that can be used, this is the name of the current participant that a file is being scaffolded for.
+Next, you should generate some starting files for your participants in their own dedicated folder, using `templateData`.
 
-Small note: templateData properties get flattened to the same level as `participants` property, so be careful of duplicate keys.
-
-```js
-export default {
-  // Put your participant names here!
-  participants: ['Joren', 'Felix'],
-
-  // Put any data here to be used inside your scaffolding template files
-  templateData: {
-    // Note: 'participants' key cannot be used inside templateData, because templateData gets flattened
-    appTitle: 'Cool Frontend App',
-
-    // It is possible to have dynamic data where you can run JS that returns a String
-    participantNameLowercase() {
-      // participantName is a special value that represents the name of the current participant
-      // that we are scaffolding files for.
-      return this.participantName.toLowerCase();
-    },
-
-    intro() {
-      // participantName is a special value that represents the name of the current participant
-      // that we are scaffolding files for.
-      return `Hi ${this.participantName}, welcome to ${this.appTitle}!`;
-    },
-  },
-};
-```
-
-> More on how to use this `templateData` further down in the Scaffold section.
-
-### Admins configuration
-
-You can also add `admins`, `adminPassword`, and `appKey`, to add admin users and authentication inside your workshop environment.
-
-This will allow admins to control some of the server's settings live, on the fly! It also allows the usage of in-browser follow mode, which mimicks VS Code Live Share's follow feature.
+This accepts an object which accepts any data which can be used inside your template files to fill in variables.
 
 ```js
 export default {
   participants: ['Joren', 'Felix'],
-  admins: ['Joren'],
-  adminPassword: 'pineapples',
-  appKey: 'some-secret-key-here',
-};
-```
-
-You can generate an app key which places it automatically for you.
-
-```sh
-yarn cwk generate-key
-```
-
-### Advanced server config
-
-Below there are some more configuration settings for cwk that you can specify.
-
-```js
-export default {
-  withoutAppShell: true, // Will not insert CWK app shell, disables most CWK features. Default false
-  enableCaching: true, // Will re-enable browser caching, discouraged for workshops, and can break some of the CWK features like the file loader
-  alwaysServeFiles: true, // overrides the file loader to always serve files to everyone
-  usingParticipantIframes: true, // if you don't use module exports for your participants index.js file and use index.html instead, set this to true. Helps prevent duplicate console logs because app shell is trying to import the file as a module and additionally also loads it through iframe.
-  participantIndexHtmlExists: false, // Set this to false if there's no index.html for the participants. Will remove the "View" button in the participant views, because there is nothing to href to.
-};
-```
-
-The boolean settings are all false by default, which is the encouraged setting.
-
-## Scaffolding participant files
-
-```sh
-yarn cwk scaffold
-```
-
-This will accept a `--dir` flag if you want to pass a different directly than the current working directory that you run it from.
-
-It expects a `cwk.config.js` file inside this directory, as well as a folder called `template` which is where you will store the file system that you want to scaffold for your participants.
-
-Optionally pass `--force` to override already existing participant files.
-
-You can create hooks for templateData properties by using the syntax: `<%= myVar %>`. The spaces are important here.
-
-Example templateData:
-
-```js
-export default {
-  participants: ['Joren'],
-
+  title: 'Frontend Workshop',
   templateData: {
     appTitle: 'Cool Frontend App',
-    intro() {
-      return `Hi ${this.participantName}, welcome to ${this.appTitle}!`;
-    },
   },
 };
 ```
 
-Example template file:
+Create a folder in your project root called `template` and create whatever files you want for your participants. They will be copied to their folder.
+
+You can use templateData as follows, using the special tags `<%=  %>` (spaces are important):
 
 ```js
-console.log('<%= intro %>');
+console.log('Hello <%= participantName %>, welcome to <%= appTitle %>!');
 ```
 
-Which outputs for participant `Joren`:
+> Note: participantName is always available by default, it is the current participant name for which we are scaffolding.
 
-```js
-console.log('Hi Joren, welcome to Cool Frontend App!');
+Then run:
+
+```sh
+cwk scaffold
 ```
 
-## Recommended scaffold
-
-The CWK app shell will render an overview of all the views of your participants.
-
-It is recommended to scaffold:
-
-- An `index.js` file in the root of the participant folder; the main entrypoint.
-- An `index.html` file in the root of the participant folder, to render and view the main entrypoint on its own.
-
-`index.js`
-
-```js
-export default `<p>Hello World!</p>`;
-```
-
-This means that the app shell will load this file as a module, and render the HTML string. This allows for the HMR (Hot Module Reload) feature to work, and means that whenever the file is changed, or other `.js` files that are imported, that the app shell will reload the module and re-render automatically.
-
-The following exports are supported:
-
-- String, just a JavaScript string that has (unsanitized) html in it
-- DOM Node/Element, will simply be appended and rendered that way
-- TemplateResult from `lit-html`
-
-Ultimately, it is `lit-html` that does the rendering work in the CWK app shell, but it's rather easy to create wrappers for other engines. Feel free to create an issue for other framework/library templates, and I'm happy to collaborate to add support!
-
-If you want your users to also be able to click on "View" for their own page, you need an `index.html` entrypoint as well.
-
-`index.html`
-
-```html
-<head>
-  <style>
-    body {
-      margin: 0;
-      padding: 0;
-    }
-  </style>
-</head>
-<body>
-  <script type="module">
-    import { setCapsule } from 'code-workshop-kit/dist/components/setCapsule.js';
-    setCapsule('Joren');
-  </script>
-</body>
-```
-
-This `setCapsule` helper imports the `index.js` for `Joren` and sets it in a capsule which enables the HMR feature, in a custom-elements friendly way as well.
-
-If you don't scaffold an `index.html`, you may want to disable `participantIndexHtmlExists` option in `cwk.config.js`, so there's no "View" button that tries to link people to it.
-
-### What if I don't use a JavaScript single entry-point file
-
-It is also possible to use plain old HTML for your participant workshop and not bother them too much with JavaScript, but in modern frontend most HTML is written inside a JavaScript template language, so a `.js` entrypoint file is the default in CWK.
-
-If you use plain old vanilla HTML/CSS/JS everywhere, that is fine, but then Hot Module Reload won't work, and you will require your participants to manually reload their page to see their file changes reflected. This is fine of course for beginner workshops :)!
-CWK will render the `index.html` through an iframe and not try to load and render `index.js` as a module. You should enable `usingParticipantIframes` option in `cwk.config.js`.
-
-> In the future, there will be a video showcasing both a super vanilla HTML CSS JS setup where we just use anchors with `href`, as well as a vanilla webcomponent/templating setup which assumes a single JS entrypoint. For now, please refer to the [demo folder](https://github.com/code-workshop-kit/cwk-frontend/tree/master/demo) which shows both.
-
-## I want to use the font of the app shell in my files
-
-In the app shell (main page) it is available and already loaded under the name `Dank mono`.
-
-To see it also in your `index.html` page itself, you may need to load the font first.
-
-Luckily, you can simply reuse the helper that CWK uses for that:
-
-```js
-import 'code-workshop-kit/dist/components/loadAndSetDankMonoFont.js';
-```
-
-or
-
-```html
-<script type="module">
-  import 'code-workshop-kit/dist/components/loadAndSetDankMonoFont.js';
-</script>
-```
+> [More on templating and scaffolds here](https://github.com/code-workshop-kit/cwk-frontend/tree/master/docs/scaffold.md)
 
 ## VS Live Share
 
@@ -280,4 +118,9 @@ See [VS Code Live Share Security docs](https://docs.microsoft.com/en-us/visualst
 
 Inside your repo, you should include a .vsls.json file, you can use this to add control over excluding or including files for your participants.
 
-> Important: if you exclude files e.g. your index.html, and you scaffold an index.html for your participants, you will need to add a .vsls.json file inside your participant folder that unexcludes index.html. See the [demo folder](https://github.com/code-workshop-kit/cwk-frontend/tree/master/demo) for example.
+> Important: if you exclude files e.g. your index.html, and you scaffold an index.html for your participants, you will need to add a .vsls.json file inside your participant folder that unexcludes index.html. See the [demo folder](https://github.com/code-workshop-kit/cwk-frontend/tree/master/demo/basic) for example.
+
+
+## Frequently Asked Questions
+
+Please refer to the [FAQ docs](https://github.com/code-workshop-kit/cwk-frontend/tree/master/docs/faq.md)

--- a/demo/basic/cwk.config.js
+++ b/demo/basic/cwk.config.js
@@ -4,7 +4,6 @@ export default {
   adminPassword: 'pineapples',
   appKey: "e123493f6645f6d0319d32736b6d892d13e5dd4e1b1c0d1b915ca49b",
   title: 'Frontend Workshop',
-  usingParticipantIframes: true,
   templateData: {
     appTitle: 'Cool Frontend App',
 

--- a/demo/spa/cwk.config.js
+++ b/demo/spa/cwk.config.js
@@ -6,6 +6,7 @@ export default {
   adminPassword: 'pineapples',
   appKey: 'c9b5cfe85ec154e2f21dc03074ac78a4d0689e2f6f083c421426871f',
   title: 'Frontend Workshop',
+  mode: 'module',
   // Put your data here to be used inside your scaffolding template files
   templateData: {
     appTitle: 'Cool Frontend App',

--- a/demo/spa/participants/.vsls.json
+++ b/demo/spa/participants/.vsls.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "http://json.schemastore.org/vsls",
-  "gitignore": "none",
-  "excludeFiles": ["!index.html"]
-}

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,48 @@
+# Configuration
+
+This section will explain some more advanced configuration.
+
+## Admins configuration
+
+You can also add `admins`, `adminPassword`, and `appKey`, to add admin users and authentication inside your workshop environment.
+
+This will allow admins to control some of the server's settings live, on the fly! It also allows the usage of in-browser follow mode, which mimicks VS Code Live Share's follow feature.
+
+```js
+export default {
+  participants: ['Joren', 'Felix'],
+  admins: ['Joren'],
+  adminPassword: 'pineapples',
+  appKey: 'some-secret-key-here',
+};
+```
+
+You can generate an app key which places it automatically for you.
+
+```sh
+yarn cwk generate-key
+```
+
+## Advanced server config
+
+Below there are some more configuration settings for cwk that you can specify. Some of these can be changed on the fly in the admin sidebar, if you've got admins enabled.
+
+```js
+export default {
+  withoutAppShell: true, // Will not insert CWK app shell, disables most CWK features. Default false
+  enableCaching: true, // Will re-enable browser caching, discouraged for workshops, and can break some of the CWK features like the file loader
+  alwaysServeFiles: true, // overrides the file loader to always serve files to everyone
+  mode: 'module', // if you want to use HMR (Hot Module Reload), set this to module and make sure participant index.js exports a template or DOM node.
+  participantIndexHtmlExists: false, // Set this to false if there's no index.html for the participants. Will remove the "View" button in the participant views, because there is nothing to href to.
+};
+```
+
+## Directory
+
+There is also a `--dir` flag for all `cwk` CLI commands. This is useful if you have your CWK files in a different directory, for example `demo` or `dist`. Keep in mind however that the folder structure that is  inside `--dir` is the same:
+
+- `cwk.config.js` --> config file CWK
+- `template` --> scaffolder input
+- `participants/<name>` --> scaffolder output
+
+This is not configurable right now.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,30 @@
+# FAQ
+
+## What if I don't use a JavaScript single entry-point file with a module export?
+
+It is also possible to use plain old HTML for your participant workshop and not bother them too much with JavaScript and ES Modules, but in modern frontend most HTML is written inside a JavaScript template language, so a `.js` entrypoint file is pretty common. This is what `module` mode assumes.
+
+If you use plain old vanilla HTML/CSS/JS everywhere, that is fine, but then Hot Module Reload won't work, and you will require your participants to manually reload their page to see their file changes reflected. This is fine of course for beginner workshops :)!
+CWK will render the `index.html` through an iframe and not try to load and render `index.js` as a module.
+
+> Please refer to the [demo folder](https://github.com/code-workshop-kit/cwk-frontend/tree/master/demo) which shows both basic and spa (which is module mode).
+
+## I want to use the font of the app shell in my files
+
+In the app shell (main page) it is available and already loaded under the name `Dank mono`.
+
+To see it also in your `index.html` page itself, you may need to load the font first.
+
+Luckily, you can simply reuse the helper that CWK uses for that:
+
+```js
+import 'code-workshop-kit/dist/components/loadAndSetDankMonoFont.js';
+```
+
+or
+
+```html
+<script type="module">
+  import 'code-workshop-kit/dist/components/loadAndSetDankMonoFont.js';
+</script>
+```

--- a/docs/module-mode.md
+++ b/docs/module-mode.md
@@ -1,0 +1,75 @@
+# Module mode
+
+It is possible to set `mode` to `'module'` in the `cwk.config.js`:
+
+```js
+export default {
+  participants: ['Joren', 'Felix'],
+  title: 'Frontend Workshop',
+  mode: 'module',
+  templateData: {
+    appTitle: 'Cool Frontend App',
+  },
+};
+```
+
+This will enable Hot Module Reload feature, and expect the participant `index.js` to have a default export that is either:
+
+- String, usually you'll want this to be valid HTML
+- DOM Node (`document.createElement('div')`)
+- TemplateResult (from lit-html):
+
+  ```js
+  html`<div></div>`
+  ```
+
+> Ultimately, it is `lit-html` that does the rendering work in the CWK app shell, but it's rather easy to create wrappers for other engines. Feel free to create an issue for other framework/library templates, and I'm happy to collaborate to add support!
+
+Example `participants/Joren/index.js`:
+
+```js
+class JorenElement extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `<h3>Hello, World!</h3>`;
+  }
+}
+customElements.define('joren-element', JorenElement);
+export default `<joren-element></joren-element>`;
+```
+
+The main benefit of module mode is that the filewatcher will instruct the app to reload the participant default exported module whenever files are changed.
+This works recursively in the sense that other imported modules will also be reloaded.
+It even works for `custom elements` because the app shell adds a ponyfill that allows for redefining custom elements to the `Custom Elements Registry`!
+
+Even better, no more iframes! This will help with performance both on the server end, as well as for sharing resources like libraries/frameworks. This is a must if you are doing a workshop where your participants import 3rd party resources.
+
+If a default export is not found, it will render an error.
+
+## HTML Entrypoint
+
+If you want your users to also be able to click on "View" for their own page, you need an `index.html` entrypoint as well.
+
+`index.html`
+
+```html
+<head>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+<body>
+  <script type="module">
+    import { setCapsule } from 'code-workshop-kit';
+    setCapsule('Joren');
+  </script>
+</body>
+```
+
+> In the template before scaffolding it, it would be `setCapsule('<%= participantName %>');`
+
+This `setCapsule` helper imports the `index.js` for `Joren` and does the same thing as inside the overview page where you can view all participants.
+
+If you don't scaffold an `index.html`, you may want to set `participantIndexHtmlExists` option in `cwk.config.js` to false, so there's no "View" button that tries to link people to it.

--- a/docs/scaffold.md
+++ b/docs/scaffold.md
@@ -1,0 +1,40 @@
+# Scaffold
+
+There are some more advanced things you can do with `templateData`.
+
+For example, you can also put methods in here, and you can access other templateData variables through `this`.
+
+There is also the special `this.participantName` that can be used, this is the name of the current participant that a file is being scaffolded for.
+
+> templateData properties get flattened to the same level as `participants` property, so be careful of duplicate keys.
+
+```js
+export default {
+  participants: ['Joren', 'Felix'],
+  templateData: {
+    appTitle: 'Cool Frontend App',
+
+    participantNameLower() {
+      return this.participantName.toLowerCase();
+    },
+
+    intro() {
+      return `Hi ${this.participantName}, welcome to ${this.appTitle}!`;
+    },
+  },
+};
+```
+
+## CLI
+
+The `cwk scaffold` command will accept a `--force` or `-f` flag to override already existing participant files completely.
+
+## Rationale
+
+I just went with `@open-wc/create` npm package and hacked some things in to make it useful for this project.
+
+However, in the future, it would be nice to "outsource" these features to a dedicated scaffolder and template engine.
+
+It should also be possible in the future to have multiple templates. For example, it's very useful if you have multiple exercises/assignments in your workshop, that you can switch between templates. The main challenge here is: how do you ensure that your participants don't lose their work when you make them switch.
+
+Ideas for all this are welcome!

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@open-wc/eslint-config": "^2.0.0",
     "@open-wc/testing": "^2.5.16",
     "@open-wc/testing-helpers": "^1.8.2",
+    "@web/test-runner-puppeteer": "^0.6.1",
     "chai": "^4.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.11.0",

--- a/src/components/AppShell.js
+++ b/src/components/AppShell.js
@@ -98,10 +98,9 @@ class AppShell extends LitElement {
         reflect: true,
         attribute: 'participant-index-html-exists',
       },
-      usingParticipantIframes: {
-        type: Boolean,
+      mode: {
+        type: String,
         reflect: true,
-        attribute: 'using-participant-iframes',
       },
     };
   }
@@ -111,7 +110,7 @@ class AppShell extends LitElement {
     window.HMR_SKIP_DEEP_PATCH = true;
     applyPolyfill();
     this.participantIndexHtmlExists = true;
-    this.usingParticipantIframes = false;
+    this.mode = 'iframe';
     setCustomCSSProps();
     this.fetchConfigComplete = new Promise(resolve => {
       this.fetchConfigResolve = resolve;
@@ -165,7 +164,7 @@ class AppShell extends LitElement {
                         html`<cwk-participant-capsule
                           .participantModuleImport=${this.participantModuleImport}
                           ?participant-index-html-exists=${this.participantIndexHtmlExists}
-                          ?using-participant-iframes=${this.usingParticipantIframes}
+                          .mode=${this.mode}
                           .name="${name}"
                           .websocketPort=${this.websocketPort}
                         ></cwk-participant-capsule>`,

--- a/src/components/ParticipantCapsule.js
+++ b/src/components/ParticipantCapsule.js
@@ -14,10 +14,9 @@ class ParticipantCapsule extends LitElement {
         reflect: true,
         attribute: 'participant-index-html-exists',
       },
-      usingParticipantIframes: {
-        type: Boolean,
+      mode: {
+        type: String,
         reflect: true,
-        attribute: 'using-participant-iframes',
       },
       participantTemplate: {
         attribute: false,
@@ -101,7 +100,7 @@ class ParticipantCapsule extends LitElement {
       this.__loadingResolve = resolve;
     });
 
-    if (!this.usingParticipantIframes) {
+    if (this.mode === 'module') {
       try {
         const participantModule = await import(
           this.participantModuleImport ||
@@ -109,7 +108,15 @@ class ParticipantCapsule extends LitElement {
         );
         this.participantTemplate = participantModule.default;
       } catch (e) {
-        throw new Error(e);
+        console.error(e);
+      }
+
+      if (this.participantTemplate === undefined) {
+        this.participantTemplate = `
+          <h3 style="font-family: Dank Mono, sans-serif; font-weight: lighter">
+            🚧 No default export with template or DOM node found in your index.js 🚧
+          </h3>
+        `;
       }
     }
     this.loading = false;

--- a/src/components/setCapsule.js
+++ b/src/components/setCapsule.js
@@ -1,7 +1,7 @@
 import { applyPolyfill } from 'custom-elements-hmr-polyfill';
 import './ParticipantCapsule.js';
 
-export const setCapsule = name => {
+export const setCapsule = (name, module = true) => {
   window.HMR_SKIP_DEEP_PATCH = true;
   applyPolyfill();
 
@@ -9,5 +9,6 @@ export const setCapsule = name => {
   capsule.name = name;
   capsule.noHeader = true;
   capsule.noContainer = true;
+  capsule.mode = module ? 'module' : 'iframe';
   document.body.appendChild(capsule);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export { setCapsule } from './components/setCapsule.js';
 export { generateKey } from './generate-key.js';
 export * from './middlewares/middlewares.js';
 export * from './plugins/plugins.js';

--- a/src/plugins/component-replacers-plugin.js
+++ b/src/plugins/component-replacers-plugin.js
@@ -36,12 +36,10 @@ export function componentReplacersPlugin(opts) {
             );
           }
 
-          if (opts.usingParticipantIframes) {
-            rewrittenBody = rewrittenBody.replace(
-              new RegExp('this.usingParticipantIframes = false;', 'g'),
-              'this.usingParticipantIframes = true;',
-            );
-          }
+          rewrittenBody = rewrittenBody.replace(
+            new RegExp("this.mode = 'iframe';", 'g'),
+            `this.mode = '${opts.mode}';`,
+          );
         }
       }
       return { body: rewrittenBody };

--- a/src/start-server.js
+++ b/src/start-server.js
@@ -130,7 +130,7 @@ const addPluginsAndMiddlewares = (edsConfig, cwkConfig, absoluteDir) => {
   newEdsConfig.plugins.push(
     componentReplacersPlugin({
       dir: absoluteDir,
-      usingParticipantIframes: cwkConfig.usingParticipantIframes,
+      mode: cwkConfig.mode,
       participantIndexHtmlExists: cwkConfig.participantIndexHtmlExists,
     }),
   );
@@ -158,7 +158,7 @@ const getCwkConfig = opts => {
     withoutAppShell: false,
     enableCaching: false,
     alwaysServeFiles: false,
-    usingParticipantIframes: false,
+    mode: 'iframe',
     participantIndexHtmlExists: true,
     dir: '/',
     title: '',
@@ -204,11 +204,9 @@ const getEdsConfig = (opts, cwkConfig, defaultPort, absoluteDir) => {
   let edsConfig = {
     open: false,
     logStartup: true,
-    watch: false,
     moduleDirs: ['node_modules'],
     nodeResolve: true,
     logErrorsToBrowser: true,
-    compatibility: 'none',
     plugins: [],
     middlewares: [],
     ...opts,
@@ -223,6 +221,14 @@ const getEdsConfig = (opts, cwkConfig, defaultPort, absoluteDir) => {
 
   edsConfig.port = edsConfig.port || defaultPort;
   edsConfig = addPluginsAndMiddlewares(edsConfig, cwkConfig, absoluteDir);
+
+  edsConfig = {
+    ...edsConfig,
+    eventStream: false, // don't insert event stream as it crashes pages with lots of iframes
+    watch: false, // watch will not work with HMR
+    compatibility: 'none', // won't work without eventStream
+  };
+
   edsConfig = createConfig(edsConfig);
   return edsConfig;
 };

--- a/test/components/participant-capsule.test.js
+++ b/test/components/participant-capsule.test.js
@@ -9,6 +9,7 @@ describe('Participant Capsule Component', () => {
         .participantModuleImport=${'../../test/utils/template-modules/string.js'}
         .websocketPort=${8000}
         .name=${'Joren'}
+        mode="module"
       ></cwk-participant-capsule>`,
     );
 
@@ -21,6 +22,7 @@ describe('Participant Capsule Component', () => {
         .name=${'Joren'}
         .websocketPort=${8000}
         .participantModuleImport=${'../../test/utils/template-modules/string.js'}
+        mode="module"
       ></cwk-participant-capsule>`,
     );
 
@@ -32,12 +34,11 @@ describe('Participant Capsule Component', () => {
     );
   });
 
-  it('falls back to rendering iframes if module import fails or if usingParticipantIframes is set to true', async () => {
+  it('renders iframes if module import fails or if mode is set to iframe', async () => {
     const el = await fixture(
       html`<cwk-participant-capsule
         .name=${'Joren'}
         .websocketPort=${8000}
-        using-participant-iframes
       ></cwk-participant-capsule>`,
     );
 
@@ -52,6 +53,7 @@ describe('Participant Capsule Component', () => {
         .name=${'Joren'}
         .websocketPort=${8000}
         .participantModuleImport=${'../../test/utils/template-modules/DOMNode.js'}
+        mode="module"
       ></cwk-participant-capsule>`,
     );
 
@@ -67,6 +69,7 @@ describe('Participant Capsule Component', () => {
         .name=${'Joren'}
         .websocketPort=${8000}
         .participantModuleImport=${'../../test/utils/template-modules/lit.js'}
+        mode="module"
       ></cwk-participant-capsule>`,
     );
 
@@ -83,6 +86,7 @@ describe('Participant Capsule Component', () => {
         .websocketPort=${8000}
         .participantModuleImport=${'../../test/utils/template-modules/string.js'}
         .name=${'Joren'}
+        mode="module"
       ></cwk-participant-capsule>`,
     );
 
@@ -93,15 +97,22 @@ describe('Participant Capsule Component', () => {
     expect(el.shadowRoot.querySelector('.button__fullscreen')).to.be.null;
   });
 
-  it('has an undefined participant template if the participant module does not exist', async () => {
+  it('has an error message participant template if the participant module does not exist', async () => {
     const el = await fixture(
       html`<cwk-participant-capsule
         participant-index-html-exists
         .websocketPort=${8000}
         .name=${'Joren'}
+        mode="module"
       ></cwk-participant-capsule>`,
     );
-    expect(el.participantTemplate).to.be.undefined;
+    expect(el.participantTemplate).to.equal(
+      `
+          <h3 style="font-family: Dank Mono, sans-serif; font-weight: lighter">
+            🚧 No default export with template or DOM node found in your index.js 🚧
+          </h3>
+        `,
+    );
   });
 
   it('renders without a container div if no-container is set to true', async () => {
@@ -112,6 +123,7 @@ describe('Participant Capsule Component', () => {
         .websocketPort=${8000}
         .participantModuleImport=${'../../test/utils/template-modules/string.js'}
         .name=${'Joren'}
+        mode="module"
       ></cwk-participant-capsule>`,
     );
     expect(el.shadowRoot.querySelector('.container')).to.be.null;
@@ -125,6 +137,7 @@ describe('Participant Capsule Component', () => {
         .websocketPort=${8000}
         .participantModuleImport=${'../../test/utils/template-modules/string.js'}
         .name=${'Joren'}
+        mode="module"
       ></cwk-participant-capsule>`,
     );
     expect(el.shadowRoot.querySelector('.header')).to.be.null;

--- a/test/node/cwk-server.test.js
+++ b/test/node/cwk-server.test.js
@@ -178,6 +178,7 @@ describe('CWK Server e2e', () => {
       ({ server, wss, moduleWatcher } = await startServer({
         ...baseCfg,
         dir: './test/utils/fixtures/simple',
+        mode: 'module',
       }));
 
       browser = await puppeteer.launch();
@@ -396,7 +397,6 @@ describe('CWK Server e2e', () => {
           ...baseCfg,
           compatibility: 'none',
           dir: './test/utils/fixtures/admins',
-          usingParticipantIframes: true,
         }));
 
         wss.on('connection', ws => {
@@ -465,7 +465,6 @@ describe('CWK Server e2e', () => {
           ...baseCfg,
           compatibility: 'none',
           dir: './test/utils/fixtures/admins',
-          usingParticipantIframes: true,
         }));
 
         wss.on('connection', ws => {

--- a/test/node/start-server.test.js
+++ b/test/node/start-server.test.js
@@ -34,7 +34,7 @@ describe('start cwk server', () => {
       expect(cwkConfig.withoutAppShell).to.be.false;
       expect(cwkConfig.enableCaching).to.be.false;
       expect(cwkConfig.alwaysServeFiles).to.be.false;
-      expect(cwkConfig.usingParticipantIframes).to.be.false;
+      expect(cwkConfig.mode).to.equal('iframe');
       expect(cwkConfig.participantIndexHtmlExists).to.be.true;
       expect(cwkConfig.title).to.equal('');
       expect(edsConfig.logStartup).to.be.true;
@@ -55,10 +55,9 @@ describe('start cwk server', () => {
         withoutAppShell: true,
         enableCaching: true,
         alwaysServeFiles: true,
-        usingParticipantIframes: true,
+        mode: 'module',
         participantIndexHtmlExists: false,
         logStartup: false,
-        watch: true,
         rootDir: path.resolve(__dirname, '../utils', 'fixtures', 'simple'),
         open: false,
       }));
@@ -67,14 +66,29 @@ describe('start cwk server', () => {
       expect(cwkConfig.withoutAppShell).to.be.true;
       expect(cwkConfig.enableCaching).to.be.true;
       expect(cwkConfig.alwaysServeFiles).to.be.true;
-      expect(cwkConfig.usingParticipantIframes).to.be.true;
+      expect(cwkConfig.mode).to.equal('module');
       expect(cwkConfig.participantIndexHtmlExists).to.be.false;
       expect(edsConfig.logStartup).to.be.false;
-      expect(edsConfig.watch).to.be.true;
       // app-shell/file-control turned off
-      expect(edsConfig.plugins.length).to.equal(8);
+      expect(edsConfig.plugins.length).to.equal(7);
       // caching middleware turned off
       expect(edsConfig.customMiddlewares.length).to.equal(2);
+    });
+
+    it('locks watch mode, compatibility and event stream to false|none, and is not overridable', async () => {
+      ({ cwkConfig, edsConfig, server, wss, moduleWatcher } = await startServer({
+        dir: './test/utils/fixtures/simple',
+        rootDir: path.resolve(__dirname, '../utils', 'fixtures', 'simple'),
+        watch: true,
+        compatibility: 'always',
+        eventStream: true,
+        open: false,
+        logStartup: false,
+      }));
+
+      expect(edsConfig.watch).to.be.false;
+      expect(edsConfig.eventStream).to.be.false;
+      expect(edsConfig.compatibility).to.be.undefined;
     });
 
     it('supports preventing certain plugins and middlewares from being added', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,15 +35,15 @@
     semver "^5.5.0"
 
 "@babel/core@^7.10.3", "@babel/core@^7.9.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.0.tgz#73b9c33f1658506887f767c26dae07798b30df76"
-  integrity sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.1.tgz#2c55b604e73a40dc21b0e52650b11c65cf276643"
+  integrity sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/generator" "^7.11.0"
     "@babel/helper-module-transforms" "^7.11.0"
     "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.11.0"
+    "@babel/parser" "^7.11.1"
     "@babel/template" "^7.10.4"
     "@babel/traverse" "^7.11.0"
     "@babel/types" "^7.11.0"
@@ -274,10 +274,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.7.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.0.tgz#a9d7e11aead25d3b422d17b2c6502c8dddef6a5d"
-  integrity sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==
+"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1", "@babel/parser@^7.7.0":
+  version "7.11.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.3.tgz#9e1eae46738bcd08e23e867bab43e7b95299a8f9"
+  integrity sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.10.5"
@@ -501,9 +501,9 @@
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-block-scoping@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz#b81b8aafefbfe68f0f65f7ef397b9ece68a6037d"
-  integrity sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz#5b7efe98852bef8d652c0b28144cd93a9e4b5215"
+  integrity sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -825,9 +825,9 @@
     source-map-support "^0.5.16"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.8.4":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.0.tgz#f10245877042a815e07f7e693faff0ae9d3a2aac"
-  integrity sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -871,10 +871,10 @@
   dependencies:
     vary "^1.1.2"
 
-"@lion/core@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@lion/core/-/core-0.8.0.tgz#6e06cbb134f7a0d680161421141f0c0ee813f749"
-  integrity sha512-26YP6ACQfUwIln+YZRNr4tget1t90vkRWKaP5Qrld6agtyy52qqmzQCY8NqA29Up5D8g4aS/bfEVZbozsrXHNQ==
+"@lion/core@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@lion/core/-/core-0.9.0.tgz#c3960f0a7476a567f94810479696f38838af2a19"
+  integrity sha512-HjEPvL4b7ZLz3WG9NRe2sebqi3XUv8WmdgcZIfIxUW0l8j/XN/KWpIS8mzd9LJOFj4BnhMAmpAloX/Z8iS0sxA==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.2.18"
     "@open-wc/scoped-elements" "^1.0.3"
@@ -882,21 +882,21 @@
     lit-html "^1.0.0"
 
 "@lion/dialog@~0.7.11":
-  version "0.7.11"
-  resolved "https://registry.yarnpkg.com/@lion/dialog/-/dialog-0.7.11.tgz#21e7c22b7266b2da91b863f5256c61847c30c026"
-  integrity sha512-5oqOpnOJ6NFkTevn5r6h55CpLNxc5Caa4dSU8GhYdt0yZFuW3Euh8Jd8UJdompSzbUi82FeT7IExfEEviJijWA==
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/@lion/dialog/-/dialog-0.7.12.tgz#ad0c80c6355d004255a1ff6ac9879a6f442a9c30"
+  integrity sha512-GgrgYYtATDUi0QhOpuLob86uNKtPaFhEYQTz1ByVohR5qNLRR6XxAZEdNJ2LS4EzO4y+vAWNlgBco2vLcDSQQw==
   dependencies:
-    "@lion/core" "0.8.0"
-    "@lion/overlays" "0.16.11"
+    "@lion/core" "0.9.0"
+    "@lion/overlays" "0.16.12"
 
-"@lion/overlays@0.16.11":
-  version "0.16.11"
-  resolved "https://registry.yarnpkg.com/@lion/overlays/-/overlays-0.16.11.tgz#816b935d915d5b99f0e47ad68e89c0055a7e2996"
-  integrity sha512-NqnmL5+q1Q6Dcv9adVNWuJntPVaIxmOMqQ7jPgE0SXHHesOMs6G2RmwLt3kGo3TfJap0VsGCqKriAmMpHTKuuw==
+"@lion/overlays@0.16.12":
+  version "0.16.12"
+  resolved "https://registry.yarnpkg.com/@lion/overlays/-/overlays-0.16.12.tgz#23884cdbeec1b7ea6b14d2dc4ec978479d8c92ca"
+  integrity sha512-anhMRCQWUe5Og071Mq274t32aG3E/opxNXv0EoNpDZ57sngdkslcZ8IpIk1ZsPF49sNZm4jfsxDzTJUteYm4Aw==
   dependencies:
-    "@lion/core" "0.8.0"
+    "@lion/core" "0.9.0"
     popper.js "^1.15.0"
-    singleton-manager "1.1.1"
+    singleton-manager "1.1.2"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -972,15 +972,15 @@
     prompts "^2.1.0"
     semver "^6.1.0"
 
-"@open-wc/dedupe-mixin@^1.2.18":
-  version "1.2.18"
-  resolved "https://registry.yarnpkg.com/@open-wc/dedupe-mixin/-/dedupe-mixin-1.2.18.tgz#2a86672fb3558fe2a2e1c5587dbaa0b485567ef1"
-  integrity sha512-1HpblP5edeENi0SKms7B+PKYdxHMBIQpaf0nAgTVsZeYgM9OJ3r9nrK/0MOUBZODAOZ1quvO3wlpuljq2hZPWA==
+"@open-wc/dedupe-mixin@^1.2.18", "@open-wc/dedupe-mixin@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.0.tgz#0df5d438285fc3482838786ee81895318f0ff778"
+  integrity sha512-UfdK1MPnR6T7f3svzzYBfu3qBkkZ/KsPhcpc3JYhsUY4hbpwNF9wEQtD4Z+/mRqMTJrKg++YSxIxE0FBhY3RIw==
 
 "@open-wc/eslint-config@^2.0.0":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@open-wc/eslint-config/-/eslint-config-2.0.6.tgz#57400e1c6ac51d63e93ce71366ee65543e2152f6"
-  integrity sha512-O+22PyMpsyiXHg9lXDbWBQoDSsBUID0agcAMT6YhLffRqg95TroImj6wKL2BGYic0d1MJv8PdPLBSi2A4J8eeg==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-wc/eslint-config/-/eslint-config-2.1.0.tgz#ac1bfa6da934df43c0b45b53bf6f2ea08a90b974"
+  integrity sha512-8qMsWoYP7LRw8C9+svGBx9XTUm10suSAFqn+o6NGrZBCtMJTECtjvu6DVoQKqizey5AZNhtM9bCNQTFGhmfLTg==
   dependencies:
     babel-eslint "^10.0.3"
     eslint "^6.7.2"
@@ -992,12 +992,12 @@
     eslint-plugin-no-only-tests "^2.4.0"
     eslint-plugin-wc "^1.2.0"
 
-"@open-wc/scoped-elements@^1.0.3", "@open-wc/scoped-elements@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-1.1.2.tgz#1cdcf52769437d8245227d31faaced8c2fd8fee0"
-  integrity sha512-2aZ8Ibfxhn1+ipBTvL8l84JTzptmGOd5NiLqlojn4QJQnJ/mEQXf9+g/Jj991ga+3nt1R+vRlO4JSrgqkCiyIQ==
+"@open-wc/scoped-elements@^1.0.3", "@open-wc/scoped-elements@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-1.2.1.tgz#b2912718da8cdd9e028c7030ac7de2b526401f93"
+  integrity sha512-6da5k3+JjnIezEhpITGxSyobzW5q10N3iZoJoZy6RzPUoCvbEYsgkpxM0jzhCO8bMQD8EiQM7pb4HlxTc2oQDQ==
   dependencies:
-    "@open-wc/dedupe-mixin" "^1.2.18"
+    "@open-wc/dedupe-mixin" "^1.3.0"
     lit-html "^1.0.0"
 
 "@open-wc/semantic-dom-diff@^0.13.16":
@@ -1012,23 +1012,23 @@
   dependencies:
     "@types/chai" "^4.2.11"
 
-"@open-wc/testing-helpers@^1.8.2", "@open-wc/testing-helpers@^1.8.4":
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/@open-wc/testing-helpers/-/testing-helpers-1.8.4.tgz#25c700ae3ce70ba586d496334b511a7c767c29f0"
-  integrity sha512-YkObNL45tX3z4MYoJnTNRRqqH8qcTmF1pqzQBRnO7XOGelktOamEODcr+YYOpftlbPFvLyegYy2wMy6M+Szdyg==
+"@open-wc/testing-helpers@^1.8.2", "@open-wc/testing-helpers@^1.8.7":
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/@open-wc/testing-helpers/-/testing-helpers-1.8.7.tgz#ae4be74f1ce427c5baf2ac8101c309c64b49b574"
+  integrity sha512-e5cDctrbIeVkm/hP9fKBNl2z3cMdoRgVLo/HxfUW4d5bnF8UeJ0wPIzhHqB420fyfBx5wQkrPCLyOdc+PcecQA==
   dependencies:
-    "@open-wc/scoped-elements" "^1.1.2"
+    "@open-wc/scoped-elements" "^1.2.1"
     lit-element "^2.2.1"
     lit-html "^1.0.0"
 
 "@open-wc/testing@^2.5.16":
-  version "2.5.19"
-  resolved "https://registry.yarnpkg.com/@open-wc/testing/-/testing-2.5.19.tgz#40e063b922e94b8650fb93f70237906c2f9e7440"
-  integrity sha512-0+dQgZbS76p55XS5fwA3BlKje+i6BIR68Ntl88lFdMqjQv02lPHHlkakZeLd6xv1hRdQlj0XIj1YIIaE18CMAA==
+  version "2.5.22"
+  resolved "https://registry.yarnpkg.com/@open-wc/testing/-/testing-2.5.22.tgz#ba5841700b83def1ba35afa74de8a7c3565cc3de"
+  integrity sha512-XsOJCIDxAlGR+BD4CAsNrVFgpnPv8qmbio+lkaJq1ku7ZBqmKi7YY7QtLPY1V2A+fvCpoLfqP68aAt3Iqoxd8A==
   dependencies:
     "@open-wc/chai-dom-equals" "^0.12.36"
     "@open-wc/semantic-dom-diff" "^0.17.9"
-    "@open-wc/testing-helpers" "^1.8.4"
+    "@open-wc/testing-helpers" "^1.8.7"
     "@types/chai" "^4.2.11"
     "@types/chai-dom" "^0.0.9"
     "@types/mocha" "^5.0.0"
@@ -1073,9 +1073,9 @@
     picomatch "^2.2.2"
 
 "@samverschueren/stream-to-observable@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
-  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
+  integrity sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==
   dependencies:
     any-observable "^0.3.0"
 
@@ -1101,10 +1101,10 @@
     "@sinonjs/commons" "^1"
     "@sinonjs/samsam" "^5.0.2"
 
-"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.0.3.tgz#86f21bdb3d52480faf0892a480c9906aa5a52938"
-  integrity sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.1.0.tgz#3afe719232b541bb6cf3411a4c399a188de21ec0"
+  integrity sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==
   dependencies:
     "@sinonjs/commons" "^1.6.0"
     lodash.get "^4.4.2"
@@ -1398,7 +1398,7 @@
   dependencies:
     "@types/puppeteer" "*"
 
-"@types/puppeteer@*":
+"@types/puppeteer@*", "@types/puppeteer@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-3.0.1.tgz#053ec20facc162b25a64785affccaa3e5817c607"
   integrity sha512-t03eNKCvWJXhQ8wkc5C6GYuSqMEdKLOX0GLMGtks25YZr38wKZlKTwGM/BoAPVtdysX7Bb9tdwrDS1+NrW3RRA==
@@ -1476,17 +1476,22 @@
   resolved "https://registry.yarnpkg.com/@web/browser-logs/-/browser-logs-0.0.1.tgz#920ed32f5dd5d43330132777499cc7fcecf9bd7f"
   integrity sha512-sr7/jagkgYGglEegGxk6KSgT7z0XtInhcwOmg5c+YvACQ3MaaAuZ6HTBf27dza24SuvBe8Q8jTiPRfu+VZ3kzQ==
 
-"@web/config-loader@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@web/config-loader/-/config-loader-0.0.3.tgz#812875b98d3f38d1e21d293bb4fbf7358243e328"
-  integrity sha512-pM3Y2ohK2xvVMsZs5tgyIe5kos7L3FrTYBlNotBgjMu+QXNqLnOmz0omYLDj91j75fksmVc6JsTOgFAUyVvGrw==
+"@web/browser-logs@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@web/browser-logs/-/browser-logs-0.1.1.tgz#4c323fa8a1a40645c5e6c53284e2e0ff7d6c3cdf"
+  integrity sha512-TpUHhGNWdryftxEx/caLPnNPd8AM2EybncYS5TurAywW0e4eTTAiGc9fJOmXRczvHdgRkyD+Z8/9Hxuyz1gorQ==
+
+"@web/config-loader@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@web/config-loader/-/config-loader-0.0.4.tgz#4beb1c14f40f0a5c1a34876bb2e2ae6b787a3ef5"
+  integrity sha512-GKXhYmeivmjIrYAXVmg1UpyZwV03XB0HhnBZX497Hfa88sxrFpv86f+zwde9UCuVZPbEBdXfWLVAkXyBTBotQA==
   dependencies:
     semver "^7.3.2"
 
-"@web/dev-server-core@^0.1.5":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-core/-/dev-server-core-0.1.8.tgz#4a2e070d02e3589c6f063d1c060fa766a24bda30"
-  integrity sha512-ZpWJteovCBuIjQ3A2sve+QKDs+Y/w001m87h47nL+Ez9+SSc0QQJAleJIbsAVIeX2d9LYSWBlTq/KBveyifR5Q==
+"@web/dev-server-core@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@web/dev-server-core/-/dev-server-core-0.1.9.tgz#afc1909e4f657519e4b1268945f6efdddf652461"
+  integrity sha512-7NMTrY2IuI82ebz6dI7DZdMWmkgkjbCPJwJfyRDvBBDfHu8ceHY1RKvX0waVpl4/bRe8R3xUCd6gn/U9ewlTfg==
   dependencies:
     chokidar "^3.4.0"
     clone "^2.1.2"
@@ -1499,26 +1504,41 @@
     lru-cache "^5.1.1"
     mime-types "^2.1.27"
     parse5 "^6.0.0"
+    picomatch "^2.2.2"
 
-"@web/dev-server-rollup@^0.1.6":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-rollup/-/dev-server-rollup-0.1.7.tgz#5916295b1eeb68f607858bf45a65b94326d1492b"
-  integrity sha512-DbefpEsnNtvabDRVzlXDp4A7OQONcZvaYsamXkLSjljuu8HGn8bgeEEII7aveaNRpCptFuHPSiDPOVhH195GPA==
+"@web/dev-server-core@^0.2.0":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@web/dev-server-core/-/dev-server-core-0.2.1.tgz#a443b248c6baa3ced0532991bc8a45fff73f58f3"
+  integrity sha512-7bVTQ24FxqmMus1tdqrl2Q4+ZFHJORg1tM2DEZG2BYCOWUbpDnc3k5fHc5EjsZM1+efaYwuQli3lUwQlVKx1ww==
   dependencies:
-    "@web/dev-server-core" "^0.1.5"
+    chokidar "^3.4.0"
+    clone "^2.1.2"
+    es-module-lexer "^0.3.24"
+    is-stream "^2.0.0"
+    isbinaryfile "^4.0.6"
+    koa "^2.13.0"
+    koa-etag "^3.0.0"
+    koa-static "^5.0.0"
+    lru-cache "^5.1.1"
+    mime-types "^2.1.27"
+    parse5 "^6.0.0"
+    picomatch "^2.2.2"
+
+"@web/dev-server-rollup@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@web/dev-server-rollup/-/dev-server-rollup-0.1.9.tgz#e63847ae40a0942afcbd7e01418a29ad4c5d7b7c"
+  integrity sha512-9sVi9MoRhXWcyjLkZyzF2JQqgX0PBAyML2wwP6B5Pkuzwp4VTtBRaLA/mQ6O7mrWgPa290Jkcb6Znhf+iwBJmA==
+  dependencies:
+    "@web/dev-server-core" "^0.1.9"
     chalk "^4.1.0"
+    parse5 "^6.0.1"
     rollup "^2.20.0"
     whatwg-url "^8.1.0"
 
-"@web/test-runner-browser-lib@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-browser-lib/-/test-runner-browser-lib-0.2.10.tgz#d21551a90114c61f6bf7183d762cd9bbe24b98f3"
-  integrity sha512-PiyXi3Mh7GsYs8yE1/qTe1x7cRnGCh2SLc3zlUMJ+WqDbdTkFvRmMBZHDtno6OEsGqp2NkjN3r2adr7o7uTv7w==
-
-"@web/test-runner-chrome@^0.5.16":
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-chrome/-/test-runner-chrome-0.5.16.tgz#801e887ff46cb34c46551922f2a33deafcad6488"
-  integrity sha512-HSUVpYmcRcKV1+PU6bKZhbSHY6SXC3FmhSFz6g5g/TGss9AEaYpv+puf6rra0x/q4Pqh8hsc+4lhjTiYrFgnlg==
+"@web/test-runner-chrome@^0.5.21":
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-chrome/-/test-runner-chrome-0.5.21.tgz#2b184eb8b4dc9c08dab043a0d2f0f8bee120792e"
+  integrity sha512-eaul81q33F7sthJoPRyKBjglFKFXL1H8CFb/AVxKlBMVD6Pwu4W45siUmHkdEZnfK3O+Djz+5wEhwKVJ/D6ifw==
   dependencies:
     "@types/puppeteer-core" "^2.0.0"
     "@web/browser-logs" "^0.0.1"
@@ -1526,16 +1546,28 @@
     chrome-launcher "^0.13.3"
     puppeteer-core "^5.0.0"
 
-"@web/test-runner-cli@^0.4.25":
-  version "0.4.25"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-cli/-/test-runner-cli-0.4.25.tgz#ebc88d6383102120b3d81c4fe9635a747a0a0a1e"
-  integrity sha512-wwpAZmtl8GuFMxbcH7c8iqYTgeLzqZzFJo7MQieK1XTrZLcL/8/GdL8woOcifzheEBOKCUVfsgGO4e08u8RKXg==
+"@web/test-runner-chrome@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-chrome/-/test-runner-chrome-0.6.1.tgz#10d06e554a72d7e88d23b09dc7ec1d7fdaa4478d"
+  integrity sha512-JLqrM/FtCbBqYDBiKXzsH91qC9verVQ9Lkv5gTI8DlYvgy01PijfBzzaIn63VBuUPS81Q50kv5f6hw8y4iG7Bg==
+  dependencies:
+    "@types/puppeteer-core" "^2.0.0"
+    "@web/browser-logs" "^0.1.1"
+    "@web/test-runner-core" "^0.7.1"
+    "@web/test-runner-coverage-v8" "^0.1.1"
+    chrome-launcher "^0.13.3"
+    puppeteer-core "^5.0.0"
+
+"@web/test-runner-cli@^0.4.30":
+  version "0.4.30"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-cli/-/test-runner-cli-0.4.30.tgz#1d96e7a106ab17ca91bb3407c87befb069fbd634"
+  integrity sha512-1TG12dQ5YW09fe2iTEJIL0ovS4pwuVUpFX1Cb7JDy+1wx73wqiI+M/mHdnvlAZQjg2OQhu5+Dh2eLHht1IuM9g==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@types/babel__code-frame" "^7.0.1"
     "@web/browser-logs" "^0.0.1"
-    "@web/config-loader" "^0.0.3"
-    "@web/test-runner-core" "^0.6.18"
+    "@web/config-loader" "^0.0.4"
+    "@web/test-runner-core" "^0.6.23"
     camelcase "^6.0.0"
     chalk "^4.1.0"
     cli-cursor "^3.1.0"
@@ -1551,11 +1583,34 @@
     portfinder "^1.0.26"
     source-map "^0.7.3"
 
-"@web/test-runner-core@^0.6.16", "@web/test-runner-core@^0.6.18", "@web/test-runner-core@^0.6.9":
-  version "0.6.18"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-core/-/test-runner-core-0.6.18.tgz#a862a4e1348cc149a4a50fce0c8f1bd1e333f535"
-  integrity sha512-TeZhW30tv/UQMwWddYAe9p9rxjihqIwkUMWSdPhJzw0QLJ+66bujWJzJLGB8BuZeUtqFHKDpbtq5VxY0rI4eqw==
+"@web/test-runner-commands@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-commands/-/test-runner-commands-0.0.1.tgz#8142a9f3d565e1076d9ea32d993fc547ce70b994"
+  integrity sha512-nJTvh/BgPRfdNA2JMQxlF8mI9zaAbBw4DJlcbfJ+w2V2aa3AaCNuWR3FcZEdb62aO8ggBU5G0x9eIw6a6Y2h6w==
   dependencies:
+    "@web/test-runner-core" "^0.6.22"
+
+"@web/test-runner-core@^0.6.22", "@web/test-runner-core@^0.6.23", "@web/test-runner-core@^0.6.9":
+  version "0.6.23"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-core/-/test-runner-core-0.6.23.tgz#949ea52c2c6578a6d1039d09b609d3d29b9b8f8e"
+  integrity sha512-GHFlANVlbtZYwyB0QhG9mgKvOzsrFzdop4Ervq0Nkc5g0CMa0xjrQAUbWeH3BKm001oXuMldlbZGdbSv5CYeEQ==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    picomatch "^2.2.2"
+    uuid "^8.1.0"
+
+"@web/test-runner-core@^0.7.1", "@web/test-runner-core@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-core/-/test-runner-core-0.7.2.tgz#2f6f36844849349387660bca6d33239aa9b4e7cd"
+  integrity sha512-ir7H4/jdWaKgGVQb6xd6krDQhWyNtfTrf9uE3OmJJ1QeFSDBUrzrVjYLABwoBEA0xdX+pQ6hjDQntiln9hx2hg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@web/dev-server-core" "^0.2.0"
+    "@web/test-runner-core" "^0.7.2"
+    co-body "^6.0.0"
+    debounce "^1.2.0"
+    deepmerge "^4.2.2"
+    dependency-graph "^0.9.0"
     istanbul-lib-coverage "^3.0.0"
     picomatch "^2.2.2"
     uuid "^8.1.0"
@@ -1569,23 +1624,41 @@
     istanbul-lib-coverage "^3.0.0"
     v8-to-istanbul "^4.1.4"
 
-"@web/test-runner-mocha@^0.2.11":
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-mocha/-/test-runner-mocha-0.2.11.tgz#5fbc7a58803f60e6dc9e5242209dd741c9b0a2ea"
-  integrity sha512-sTCRzGQxqsemSYbdF3wWMsaXIqQyGWGyFtMXbRMxvg9/nr9p01B+tSCoxGZj0SDBSV253svt92bPFgrbPj2SNQ==
+"@web/test-runner-coverage-v8@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-coverage-v8/-/test-runner-coverage-v8-0.1.1.tgz#ae4d6c94969346db8ef617a08cde7e7d1a8fc1d0"
+  integrity sha512-bDGn7Bja9IhpHAobgecTt9OTWuQKq/hOqyNRC7Pzofpni74D/wPQT2++qRdvGW+1+2iPAmg0QQ27tfRwHJWPww==
+  dependencies:
+    "@web/test-runner-core" "^0.7.1"
+    istanbul-lib-coverage "^3.0.0"
+    v8-to-istanbul "^4.1.4"
+
+"@web/test-runner-mocha@^0.2.15":
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-mocha/-/test-runner-mocha-0.2.15.tgz#e17feb7519e9dcb2d357ed5402260ebb041853ca"
+  integrity sha512-Z9MQQ6ztSPHrRozF3HXRNgs1+xr0kpvx7jpkgElQ7bIfHps6k3aMYhlhCGirZ8fRKQi3hbUbnApUuOd3FypoQA==
   dependencies:
     "@types/mocha" "^7.0.2"
-    "@web/test-runner-browser-lib" "^0.2.10"
     mocha "^7.2.0"
 
-"@web/test-runner-server@^0.5.12":
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-server/-/test-runner-server-0.5.12.tgz#3a28bc497d3f3bad26430a6a9a82ea675a46504a"
-  integrity sha512-jT3JT3/0C4GeZZ5wmqNNkXs//vOPmAUJj6W9MChmG/tHCHiEC3QENhnoy/oGYOwaNLqhjenlOf6HGQt+Oh9TzA==
+"@web/test-runner-puppeteer@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-puppeteer/-/test-runner-puppeteer-0.6.1.tgz#6a74e75f8a0251a8baa3044708eaee053ca21784"
+  integrity sha512-1tZmBEJoUmnDYnbvvuAZFwFelXN6dhAxmdYc/RfKhm274Q00pMO5Dk+0sLYPdpSA5MKu673wMSlsldhBe1zClw==
+  dependencies:
+    "@types/puppeteer" "^3.0.1"
+    "@web/test-runner-chrome" "^0.6.1"
+    "@web/test-runner-core" "^0.7.1"
+    puppeteer "^5.1.0"
+
+"@web/test-runner-server@^0.5.16":
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-server/-/test-runner-server-0.5.16.tgz#6cfc04ebf821f5cfe6bc26f3683bb72dd01b9ce6"
+  integrity sha512-piCYIyuhT+g3MN6SgqCL/qkrAQ+yDidHwq8MzBwZYAjTkHNnCcYxHaGVcpADvMFjCKMX1+EV/TBaU8UxXFj/Vg==
   dependencies:
     "@babel/code-frame" "^7.10.4"
-    "@web/dev-server-core" "^0.1.5"
-    "@web/test-runner-core" "^0.6.16"
+    "@web/dev-server-core" "^0.1.9"
+    "@web/test-runner-core" "^0.6.22"
     co-body "^6.0.0"
     debounce "^1.2.0"
     deepmerge "^4.2.2"
@@ -1593,17 +1666,18 @@
     picomatch "^2.2.2"
 
 "@web/test-runner@^0.6.33":
-  version "0.6.54"
-  resolved "https://registry.yarnpkg.com/@web/test-runner/-/test-runner-0.6.54.tgz#38fd79f72680527c32b329d48c6cb79212164755"
-  integrity sha512-CZEDDPWoxMt+Qqc2SM+u/5UUEt7WVjWOGnKZW6cRvYlKVXMJ/Ow/hwDskZFSKDEAt8TEC8XS8xHGzcJ+oPu7cw==
+  version "0.6.65"
+  resolved "https://registry.yarnpkg.com/@web/test-runner/-/test-runner-0.6.65.tgz#e3fe956a0d59499ee882cbc4c2caea751308cfa7"
+  integrity sha512-grKiHrfWWXNGU9N2B0DJ+9ILpeNVE6mphbdX3ULx1TPMhdaYdzDr01hYydH6NdC40EcAmI9lcAFHLcZQe3QwQg==
   dependencies:
     "@rollup/plugin-node-resolve" "^8.1.0"
-    "@web/dev-server-rollup" "^0.1.6"
-    "@web/test-runner-chrome" "^0.5.16"
-    "@web/test-runner-cli" "^0.4.25"
-    "@web/test-runner-core" "^0.6.18"
-    "@web/test-runner-mocha" "^0.2.11"
-    "@web/test-runner-server" "^0.5.12"
+    "@web/dev-server-rollup" "^0.1.9"
+    "@web/test-runner-chrome" "^0.5.21"
+    "@web/test-runner-cli" "^0.4.30"
+    "@web/test-runner-commands" "^0.0.1"
+    "@web/test-runner-core" "^0.6.23"
+    "@web/test-runner-mocha" "^0.2.15"
+    "@web/test-runner-server" "^0.5.16"
     command-line-args "^5.1.1"
     deepmerge "^4.2.2"
 
@@ -1644,9 +1718,9 @@ acorn-jsx@^5.2.0:
   integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
 
 acorn@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
-  integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
+  integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -1659,9 +1733,9 @@ agent-base@5:
   integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 ajv@^6.10.0, ajv@^6.10.2:
-  version "6.12.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
-  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
+  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1998,14 +2072,14 @@ browserslist-useragent@^3.0.2:
     useragent "^2.3.0"
 
 browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.8.5, browserslist@^4.9.1:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.13.0.tgz#42556cba011e1b0a2775b611cba6a8eca18e940d"
-  integrity sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.0.tgz#2908951abfe4ec98737b72f34c3bcedc8d43b000"
+  integrity sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==
   dependencies:
-    caniuse-lite "^1.0.30001093"
-    electron-to-chromium "^1.3.488"
-    escalade "^3.0.1"
-    node-releases "^1.1.58"
+    caniuse-lite "^1.0.30001111"
+    electron-to-chromium "^1.3.523"
+    escalade "^3.0.2"
+    node-releases "^1.1.60"
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
@@ -2151,10 +2225,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001033, caniuse-lite@^1.0.30001093:
-  version "1.0.30001109"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001109.tgz#a9f3f26a0c3753b063d7acbb48dfb9c0e46f2b19"
-  integrity sha512-4JIXRodHzdS3HdK8nSgIqXYLExOvG+D2/EenSvcub2Kp3QEADjo2v2oUn5g0n0D+UNwG9BtwKOyGcSq2qvQXvQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001033, caniuse-lite@^1.0.30001111:
+  version "1.0.30001114"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001114.tgz#2e88119afb332ead5eaa330e332e951b1c4bfea9"
+  integrity sha512-ml/zTsfNBM+T1+mjglWRPgVsu2L76GAaADKX5f4t0pbhttEp0WMawJsHDYlFkVZkoA+89uvBRrVrEE4oqenzXQ==
 
 chai-a11y-axe@^1.3.0:
   version "1.3.0"
@@ -2253,9 +2327,9 @@ chokidar@^2.1.8:
     fsevents "^1.2.7"
 
 chokidar@^3.0.0, chokidar@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.1.tgz#e905bdecf10eaa0a0b1db0c664481cc4cbc22ba1"
-  integrity sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -2451,6 +2525,14 @@ compare-func@^1.3.1:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
 
+compare-func@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/compare-func/-/compare-func-2.0.0.tgz#fb65e75edbddfd2e568554e8b5b05fff7a51fcb3"
+  integrity sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==
+  dependencies:
+    array-ify "^1.0.0"
+    dot-prop "^5.1.0"
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -2501,11 +2583,11 @@ content-type@^1.0.4:
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
 conventional-changelog-angular@^5.0.10:
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz#5cf7b00dd315b6a6a558223c80d5ef24ddb34205"
-  integrity sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz#99a3ca16e4a5305e0c2c2fae3ef74fd7631fc3fb"
+  integrity sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==
   dependencies:
-    compare-func "^1.3.1"
+    compare-func "^2.0.0"
     q "^1.5.1"
 
 conventional-changelog-atom@^2.0.7:
@@ -2527,7 +2609,7 @@ conventional-changelog-config-spec@2.1.0:
   resolved "https://registry.yarnpkg.com/conventional-changelog-config-spec/-/conventional-changelog-config-spec-2.1.0.tgz#874a635287ef8b581fd8558532bf655d4fb59f2d"
   integrity sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ==
 
-conventional-changelog-conventionalcommits@4.3.0, conventional-changelog-conventionalcommits@^4.3.0:
+conventional-changelog-conventionalcommits@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.3.0.tgz#c4205a659f7ca9d7881f29ee78a4e7d6aeb8b3c2"
   integrity sha512-oYHydvZKU+bS8LnGqTMlNrrd7769EsuEHKy4fh1oMdvvDi7fem8U+nvfresJ1IDB8K00Mn4LpiA/lR+7Gs6rgg==
@@ -2536,19 +2618,28 @@ conventional-changelog-conventionalcommits@4.3.0, conventional-changelog-convent
     lodash "^4.17.15"
     q "^1.5.1"
 
+conventional-changelog-conventionalcommits@^4.3.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.4.0.tgz#8d96687141c9bbd725a89b95c04966d364194cd4"
+  integrity sha512-ybvx76jTh08tpaYrYn/yd0uJNLt5yMrb1BphDe4WBredMlvPisvMghfpnJb6RmRNcqXeuhR6LfGZGewbkRm9yA==
+  dependencies:
+    compare-func "^2.0.0"
+    lodash "^4.17.15"
+    q "^1.5.1"
+
 conventional-changelog-core@^4.1.7:
-  version "4.1.7"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-4.1.7.tgz#6b5cdadda4430895cc4a75a73dd8b36e322ab346"
-  integrity sha512-UBvSrQR2RdKbSQKh7RhueiiY4ZAIOW3+CSWdtKOwRv+KxIMNFKm1rOcGBFx0eA8AKhGkkmmacoTWJTqyz7Q0VA==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-4.2.0.tgz#d8befd1e1f5126bf35a17668276cc8c244650469"
+  integrity sha512-8+xMvN6JvdDtPbGBqA7oRNyZD4od1h/SIzrWqHcKZjitbVXrFpozEeyn4iI4af1UwdrabQpiZMaV07fPUTGd4w==
   dependencies:
     add-stream "^1.0.0"
-    conventional-changelog-writer "^4.0.16"
+    conventional-changelog-writer "^4.0.17"
     conventional-commits-parser "^3.1.0"
     dateformat "^3.0.0"
     get-pkg-repo "^1.0.0"
     git-raw-commits "2.0.0"
     git-remote-origin-url "^2.0.0"
-    git-semver-tags "^4.0.0"
+    git-semver-tags "^4.1.0"
     lodash "^4.17.15"
     normalize-package-data "^2.3.5"
     q "^1.5.1"
@@ -2586,11 +2677,11 @@ conventional-changelog-jquery@^3.0.10:
     q "^1.5.1"
 
 conventional-changelog-jshint@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.7.tgz#955a69266951cd31e8afeb3f1c55e0517fdca943"
-  integrity sha512-qHA8rmwUnLiIxANJbz650+NVzqDIwNtc0TcpIa0+uekbmKHttidvQ1dGximU3vEDdoJVKFgR3TXFqYuZmYy9ZQ==
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.8.tgz#3fff4df8cb46037f77b9dc3f8e354c7f99332f13"
+  integrity sha512-hB/iI0IiZwnZ+seYI+qEQ4b+EMQSEC8jGIvhO2Vpz1E5p8FgLz75OX8oB1xJWl+s4xBMB6f8zJr0tC/BL7YOjw==
   dependencies:
-    compare-func "^1.3.1"
+    compare-func "^2.0.0"
     q "^1.5.1"
 
 conventional-changelog-preset-loader@^2.3.4:
@@ -2598,12 +2689,12 @@ conventional-changelog-preset-loader@^2.3.4:
   resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz#14a855abbffd59027fd602581f1f34d9862ea44c"
   integrity sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==
 
-conventional-changelog-writer@^4.0.16:
-  version "4.0.16"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz#ca10f2691a8ea6d3c2eb74bd35bcf40aa052dda5"
-  integrity sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==
+conventional-changelog-writer@^4.0.17:
+  version "4.0.17"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz#4753aaa138bf5aa59c0b274cb5937efcd2722e21"
+  integrity sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==
   dependencies:
-    compare-func "^1.3.1"
+    compare-func "^2.0.0"
     conventional-commits-filter "^2.0.6"
     dateformat "^3.0.0"
     handlebars "^4.7.6"
@@ -2991,6 +3082,13 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
+dot-prop@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz#c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb"
+  integrity sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==
+  dependencies:
+    is-obj "^2.0.0"
+
 dotgitignore@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/dotgitignore/-/dotgitignore-2.1.0.tgz#a4b15a4e4ef3cf383598aaf1dfa4a04bcc089b7b"
@@ -3016,10 +3114,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.488:
-  version "1.3.516"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.516.tgz#03ec071b061e462b786bf7e7ce226fd7ab7cf1f6"
-  integrity sha512-WDM5AAQdOrvLqSX8g3Zd5AujBXfMxf96oeZkff0U2HF5op3tjShE+on2yay3r1UD4M9I3p0iHpAS4+yV8U8A9A==
+electron-to-chromium@^1.3.523:
+  version "1.3.533"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.533.tgz#d7e5ca4d57e9bc99af87efbe13e7be5dde729b0f"
+  integrity sha512-YqAL+NXOzjBnpY+dcOKDlZybJDCOzgsq4koW3fvyty/ldTmsb4QazZpOWmVvZ2m0t5jbBf7L0lIGU3BUipwG+A==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3078,9 +3176,9 @@ es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
     string.prototype.trimstart "^1.0.1"
 
 es-dev-server@^1.56.1:
-  version "1.57.1"
-  resolved "https://registry.yarnpkg.com/es-dev-server/-/es-dev-server-1.57.1.tgz#c6ed4d8f4961215ce9c50f3c58604f047737eebe"
-  integrity sha512-wdYZCVNdCJxM9Z8V+lAqw6XfUTQZRhjbkU4Fdk/UcZqB6gJ2VaaafdBBwue9L3EWu6zVJz63btpA4Xe+kVqGUw==
+  version "1.57.2"
+  resolved "https://registry.yarnpkg.com/es-dev-server/-/es-dev-server-1.57.2.tgz#e673d90a96a440cbbc0394d50157e4abfc84d83c"
+  integrity sha512-gk2z0KoeV1Z8vgZiPRQCenoomdz8Pe3mMZzI9bVetreZHB8gkkHb07d5eFiTnDxMCht65ErFr0h/Yk/i9C2+5Q==
   dependencies:
     "@babel/core" "^7.9.0"
     "@babel/plugin-proposal-dynamic-import" "^7.8.3"
@@ -3138,7 +3236,7 @@ es-dev-server@^1.56.1:
     open "^7.0.3"
     parse5 "^5.1.1"
     path-is-inside "^1.0.2"
-    polyfills-loader "^1.6.1"
+    polyfills-loader "^1.7.0"
     portfinder "^1.0.21"
     rollup "^2.7.2"
     strip-ansi "^5.2.0"
@@ -3166,7 +3264,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escalade@^3.0.1:
+escalade@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
   integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
@@ -3221,9 +3319,9 @@ eslint-plugin-babel@^5.3.0:
     eslint-rule-composer "^0.3.0"
 
 eslint-plugin-html@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-6.0.2.tgz#fcbd293e218d03dd72c147fc999d185c6f5989fe"
-  integrity sha512-Ik/z32UteKLo8GEfwNqVKcJ/WOz/be4h8N5mbMmxxnZ+9aL9XczOXQFz/bGu+nAGVoRg8CflldxJhONFpqlrxw==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-6.0.3.tgz#8d9d2c187d1a48ed78d84f45e29820f102425e51"
+  integrity sha512-1KV2ebQHywlXkfpXOGjxuEyoq+g6AWvD6g9TB28KsGhbM5rJeHXAEpHOev6LqZv6ylcfa9BWokDsNVKyYefzGw==
   dependencies:
     htmlparser2 "^4.1.0"
 
@@ -3375,9 +3473,9 @@ estraverse@^4.1.0, estraverse@^4.1.1:
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 estree-walker@^1.0.1:
   version "1.0.1"
@@ -3753,9 +3851,9 @@ get-stream@^4.0.0:
     pump "^3.0.0"
 
 get-stream@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
-  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
 
@@ -3783,10 +3881,10 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
-git-semver-tags@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-4.0.0.tgz#a9dd58a0dd3561a4a9898b7e9731cf441c98fc38"
-  integrity sha512-LajaAWLYVBff+1NVircURJFL8TQ3EMIcLAfHisWYX/nPoMwnTYfWAznQDmMujlLqoD12VtLmoSrF1sQ5MhimEQ==
+git-semver-tags@^4.0.0, git-semver-tags@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-4.1.0.tgz#0146c9bc24ee96104c99f443071c8c2d7dc848e3"
+  integrity sha512-TcxAGeo03HdErzKzi4fDD+xEL7gi8r2Y5YSxH6N2XYdVSV5UkBwfrt7Gqo1b+uSHCjy/sa9Y6BBBxxFLxfbhTg==
   dependencies:
     meow "^7.0.0"
     semver "^6.0.0"
@@ -4283,9 +4381,9 @@ is-directory@^0.3.1:
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-docker@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
-  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
+  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -4367,6 +4465,11 @@ is-obj@^1.0.0, is-obj@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+
 is-observable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
@@ -4421,9 +4524,9 @@ is-promise@^2.1.0:
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
 is-regex@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
-  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
+  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
   dependencies:
     has-symbols "^1.0.1"
 
@@ -5029,9 +5132,9 @@ lodash.uniq@^4.5.0:
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@2.2.0, log-symbols@^2.2.0:
   version "2.2.0"
@@ -5199,17 +5302,15 @@ meow@^4.0.0:
     trim-newlines "^2.0.0"
 
 meow@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-7.0.1.tgz#1ed4a0a50b3844b451369c48362eb0515f04c1dc"
-  integrity sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-7.1.0.tgz#50ecbcdafa16f8b58fb7eb9675b933f6473b3a59"
+  integrity sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==
   dependencies:
     "@types/minimist" "^1.2.0"
-    arrify "^2.0.1"
-    camelcase "^6.0.0"
     camelcase-keys "^6.2.2"
     decamelize-keys "^1.1.0"
     hard-rejection "^2.1.0"
-    minimist-options "^4.0.2"
+    minimist-options "4.1.0"
     normalize-package-data "^2.5.0"
     read-pkg-up "^7.0.1"
     redent "^3.0.0"
@@ -5288,15 +5389,7 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist-options@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
-  integrity sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==
-  dependencies:
-    arrify "^1.0.1"
-    is-plain-obj "^1.1.0"
-
-minimist-options@^4.0.2:
+minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
   integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
@@ -5304,6 +5397,14 @@ minimist-options@^4.0.2:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
+
+minimist-options@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
+  integrity sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
 
 minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
@@ -5472,7 +5573,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nise@^4.0.1:
+nise@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
   integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
@@ -5516,7 +5617,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-releases@^1.1.58:
+node-releases@^1.1.60:
   version "1.1.60"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.60.tgz#6948bdfce8286f0b5d0e5a88e8384e954dfe7084"
   integrity sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==
@@ -5673,9 +5774,9 @@ onetime@^2.0.0:
     mimic-fn "^1.0.0"
 
 onetime@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.1.tgz#5c8016847b0d67fcedb7eef254751cfcdc7e9418"
-  integrity sha512-ZpZpjcJeugQfWsfyQlshVoowIIQ1qBGSVll4rfDq6JJVO//fesjoX808hXWfBjY+ROZgpKDI5TRSRBSoJiZ8eg==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
 
@@ -5994,10 +6095,10 @@ please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
   dependencies:
     semver-compare "^1.0.0"
 
-polyfills-loader@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/polyfills-loader/-/polyfills-loader-1.6.1.tgz#134ab74b9a6160efb4d72066a5150bfb2228fad3"
-  integrity sha512-GK3jZGLy9nApfRYfHrrO4RYkBkpjiXUVWVdp169g4Y8HV+ZazrGQX46tNpbwP0dtrgHgADyJvZYPfdFuooHy5Q==
+polyfills-loader@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/polyfills-loader/-/polyfills-loader-1.7.0.tgz#f0d6155bcadb6b3066c2db448dc180a0c0b1ac8d"
+  integrity sha512-OQvUeVp0Q+qPyj7aufW9c5/W2pWvbXcVAAibCCPX6o8b2qaY4vZ4tpdHa6gq1rMeX4I8xQVIPjHNu0tKxIqjQQ==
   dependencies:
     "@babel/core" "^7.9.0"
     "@open-wc/building-utils" "^2.18.0"
@@ -6118,6 +6219,24 @@ puppeteer@^3.2.0:
     extract-zip "^2.0.0"
     https-proxy-agent "^4.0.0"
     mime "^2.0.3"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^3.0.2"
+    tar-fs "^2.0.0"
+    unbzip2-stream "^1.3.3"
+    ws "^7.2.3"
+
+puppeteer@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.2.1.tgz#7f0564f0a5384f352a38c8cc42af875cd87f4ea6"
+  integrity sha512-PZoZG7u+T6N1GFWBQmGVG162Ak5MAy8nYSVpeeQrwJK2oYUlDWpHEJPcd/zopyuEMTv7DiztS1blgny1txR2qw==
+  dependencies:
+    debug "^4.1.0"
+    devtools-protocol "0.0.781568"
+    extract-zip "^2.0.0"
+    https-proxy-agent "^4.0.0"
+    mime "^2.0.3"
+    pkg-dir "^4.2.0"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"
     rimraf "^3.0.2"
@@ -6501,9 +6620,9 @@ rimraf@^3.0.2:
     glob "^7.1.3"
 
 rollup@^2.20.0, rollup@^2.7.2:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.23.0.tgz#b7ab1fee0c0e60132fd0553c4df1e9cdacfada9d"
-  integrity sha512-vLNmZFUGVwrnqNAJ/BvuLk1MtWzu4IuoqsH9UWK5AIdO3rt8/CSiJNvPvCIvfzrbNsqKbNzPAG1V2O4eTe2XZg==
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.26.0.tgz#736ffa773fe0cefdfd0b9669abdce444d6a68f07"
+  integrity sha512-1kwpBuxQERz+ymjPLepaXqf3NMRDwSumuEfW/fsTtflmyyhI6ev7nLy5Vdadvn01zd0WWAojRuvA2+0coPGCGQ==
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -6644,10 +6763,10 @@ simple-git@^1.85.0:
   dependencies:
     debug "^4.0.1"
 
-singleton-manager@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/singleton-manager/-/singleton-manager-1.1.1.tgz#06f1a6edc6f6155caea1d4b5cb47860d6652f64a"
-  integrity sha512-NshenInyPGwH9V8YGWiej1Rk5hirhyuEQ6/lGLk2WHquDFkNwhPjvq60gViDA+0nqYAHidnu3792DJDwvbPXxw==
+singleton-manager@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/singleton-manager/-/singleton-manager-1.1.2.tgz#35c90b9f86012e4bc3342183a39fae27e8f05f24"
+  integrity sha512-U1nD22iUUVSWY7ST5iB0ca+qFZcXwtP6nf8Gp0WP/u4gqOs83gdOsOS6d4glhvcJ751ERJfDbaMoqDA0pPk+yA==
 
 sinon-chai@^3.3.0:
   version "3.5.0"
@@ -6655,16 +6774,16 @@ sinon-chai@^3.3.0:
   integrity sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==
 
 sinon@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.0.2.tgz#b9017e24633f4b1c98dfb6e784a5f0509f5fd85d"
-  integrity sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.0.3.tgz#bffc3ec28c936332cd2a41833547b9eed201ecff"
+  integrity sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==
   dependencies:
     "@sinonjs/commons" "^1.7.2"
     "@sinonjs/fake-timers" "^6.0.1"
     "@sinonjs/formatio" "^5.0.1"
-    "@sinonjs/samsam" "^5.0.3"
+    "@sinonjs/samsam" "^5.1.0"
     diff "^4.0.2"
-    nise "^4.0.1"
+    nise "^4.0.4"
     supports-color "^7.1.0"
 
 sisteransi@^1.0.4:
@@ -7060,9 +7179,9 @@ synchronous-promise@^2.0.6:
   integrity sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA==
 
 systemjs@^6.3.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.4.1.tgz#9a934cf92d6b6aa84390a84f315dede85f2e06cb"
-  integrity sha512-xnRrngh0/KGCm8J3zmhaPxBEvDB9eLAguWPo84heVwr15JM+wS11CKxSWmv0CV16VuKlRZcDscGuXgqLBRg/qw==
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.5.0.tgz#42e5e19e324e99b6e96a946697fddb3de9f6f3d5"
+  integrity sha512-B+NzKJD1srC/URfNVBdDExAUAsAVXpVQxZxX54AtqU0xiK9imkqurQu3qi6JdyA2GBAw2ssjolYIa7kh+xY1uw==
 
 table-layout@^1.0.0:
   version "1.0.1"
@@ -7323,9 +7442,9 @@ typical@^5.0.0, typical@^5.2.0:
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 uglify-js@^3.1.4, uglify-js@^3.5.1:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.10.0.tgz#397a7e6e31ce820bfd1cb55b804ee140c587a9e7"
-  integrity sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.10.1.tgz#dd14767eb7150de97f2573a5ff210db14fffe4ad"
+  integrity sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==
 
 unbzip2-stream@^1.3.3:
   version "1.4.3"
@@ -7478,9 +7597,9 @@ webidl-conversions@^5.0.0:
   integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
 
 whatwg-fetch@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz#8e134f701f0a4ab5fda82626f113e2b647fd16dc"
-  integrity sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz#e11de14f4878f773fbebcde8871b2c0699af8b30"
+  integrity sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
BREAKING CHANGE: usingParticipantIframes option is removed, use mode instead. watch and compatibility is disallowed, and EDS event stream is no longer inserted. In module mode, capsule no longer falls back to iframe, but renders an error instead, so no more mixes of participants using modules and some using iframes due to fallback.